### PR TITLE
Fix helper protocol linkage and pointer usage

### DIFF
--- a/GlassGauge/Shared/GlassGaugeHelperProtocol.swift
+++ b/GlassGauge/Shared/GlassGaugeHelperProtocol.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+@objc public protocol GlassGaugeHelperProtocol {
+    /// Runs `powermetrics` with arguments and returns (exitCode, stdout).
+    func runPowermetrics(_ arguments: [String], withReply: @escaping (Int32, String) -> Void)
+}


### PR DESCRIPTION
## Summary
- include GlassGaugeHelperProtocol in the main app so XPC interfaces build
- correctly allocate AuthorizationRights when requesting privileges
- guard SMJobBless with an availability check for macOS 13+

## Testing
- `swiftc GlassGauge/Shared/GlassGaugeHelperProtocol.swift` *(fails: Objective-C interoperability is disabled)*
- `swiftc GlassGauge/App/SMBlessedHelperManager.swift` *(fails: no such module 'ServiceManagement')*

------
https://chatgpt.com/codex/tasks/task_e_6895882159d4832783b38f16e77b47f2