### PR TITLE
Fix helper protocol linkage and pointer usage

### DIFF
--- a/GlassGauge/AppState.swift
+++ b/GlassGauge/AppState.swift
@@ -43,18 +43,18 @@ final class AppState: ObservableObject {
         helperStatus = UnifiedHelperManager.shared.getHelperStatus()
         
         // Try to establish connection asynchronously
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            UnifiedHelperManager.shared.ensureHelperIsReady { [weak self] result in
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: {
+            UnifiedHelperManager.shared.ensureHelperIsReady { [weak self] (result: Result<Void, Error>) in
                 DispatchQueue.main.async {
                     switch result {
                     case .success:
                         self?.hasPrivilegedAccess = true
                         self?.helperStatus = "Connected"
                         print("✅ Privileged access available")
-                        
+
                         // Test with a simple sensor call
                         self?.testHelperConnection()
-                        
+
                     case .failure(let error):
                         self?.hasPrivilegedAccess = false
                         self?.helperStatus = "Error: \(error.localizedDescription)"
@@ -62,7 +62,7 @@ final class AppState: ObservableObject {
                     }
                 }
             }
-        }
+        })
     }
     
     private func testHelperConnection() {
@@ -70,7 +70,7 @@ final class AppState: ObservableObject {
         
         UnifiedHelperManager.shared.runPowermetrics(
             arguments: ["--samplers", "smc", "-n", "1", "-i", "100"]
-        ) { [weak self] exitCode, output in
+        ) { [weak self] (exitCode: Int32, output: String) in
             DispatchQueue.main.async {
                 if exitCode == 0 && !output.isEmpty {
                     print("✅ Helper test successful, got \(output.count) chars of sensor data")
@@ -289,7 +289,7 @@ final class AppState: ObservableObject {
             
             UnifiedHelperManager.shared.runPowermetrics(
                 arguments: ["--samplers", "smc", "-n", "1", "-i", "200"]
-            ) { exitCode, output in
+            ) { (exitCode: Int32, output: String) in
                 if exitCode == 0 && !output.isEmpty {
                     DispatchQueue.main.async {
                         self.parsePrivilegedSensorData(output)

--- a/GlassGauge/Shared/GlassGaugeHelperProtocol.swift
+++ b/GlassGauge/Shared/GlassGaugeHelperProtocol.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+@objc public protocol GlassGaugeHelperProtocol {
+    /// Runs `powermetrics` with arguments and returns (exitCode, stdout).
+    func runPowermetrics(_ arguments: [String], withReply: @escaping (Int32, String) -> Void)
+}

--- a/GlassGaugeHelper/Helper/main.swift
+++ b/GlassGaugeHelper/Helper/main.swift
@@ -1,8 +1,0 @@
-// main.swift (helper target)
-import Foundation
-
-let listener = NSXPCListener(machServiceName: "com.zeiglerstudios.glassgauge.helper")
-let delegate = HelperTool()
-listener.delegate = delegate
-listener.resume()
-RunLoop.main.run()


### PR DESCRIPTION
## Summary
- include GlassGaugeHelperProtocol in the main app so XPC interfaces build
- correctly allocate AuthorizationRights when requesting privileges
- guard SMJobBless with an availability check for macOS 13+
- verify helper connections with `SecCodeCopyGuestWithAttributes` and use `@main` helper entry
- type closure parameters in AppState and schedule helper setup explicitly

## Testing
- `swiftc GlassGauge/Shared/GlassGaugeHelperProtocol.swift` *(fails: Objective-C interoperability is disabled)*
- `swiftc GlassGauge/AppState.swift Managers/UnifiedHelperManager.swift` *(fails: no such module 'Combine')*
- `swiftc GlassGaugeHelper/Helper/HelperTool.swift` *(fails: no such module 'os.log')*

------
https://chatgpt.com/codex/tasks/task_e_6895882159d4832783b38f16e77b47f2